### PR TITLE
Ed25519 installation fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,14 +748,15 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coins": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/coins/-/coins-2.2.3.tgz",
-      "integrity": "sha512-inPbLJOkkoSltXrwCHDNlnbX2JZei9PULjsNQLa3zTB55i+gmox6423nvgbLpy6uvJlbqDoQxW+pWHlWZYDamw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/coins/-/coins-2.2.4.tgz",
+      "integrity": "sha512-55T3OrLIk0R6aGxnXcIjYkmbZJVhdxHgRQ6lwWP1fqKEcPwWhQm/IAHVfPerssZ7FBpfF0MY6Ae41uf2igHquw==",
       "requires": {
         "bs58check": "2.1.1",
         "ed25519-supercop": "1.0.2",
         "json-stable-stringify": "1.0.1",
-        "secp256k1": "3.4.0"
+        "secp256k1": "3.4.0",
+        "supercop.js": "2.0.1"
       }
     },
     "combine-source-map": {
@@ -1201,6 +1202,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ed25519-supercop/-/ed25519-supercop-1.0.2.tgz",
       "integrity": "sha1-gOadCB0hZHtc1OOR1aO4Qhramc4=",
+      "optional": true,
       "requires": {
         "nan": "2.8.0"
       }
@@ -3223,9 +3225,9 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lotion": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/lotion/-/lotion-0.1.10.tgz",
-      "integrity": "sha512-mWcP4QoCnQzz1fnCvelnUDbnZJcI3vCBrS0XZGie2C/Lfyc/dYup2gi0fgxJZCI68foKGBgvvZYwChWKoEp/Mg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/lotion/-/lotion-0.1.11.tgz",
+      "integrity": "sha512-3j7TDpsj/gQ6EGR3r9SvBPvhOY+NLrhus3HFzpAcijiQhbMP2M5efznM7lhKpkd/cxZ3TamPZo/OaMeXXNX/eg==",
       "requires": {
         "axios": "0.16.2",
         "body-parser": "1.18.2",
@@ -3246,7 +3248,7 @@
         "memdown": "1.4.1",
         "mkdirp": "0.5.1",
         "protobufjs": "6.8.4",
-        "tendermint": "3.1.0",
+        "tendermint": "3.1.1",
         "unzip": "0.1.11",
         "varstruct": "6.1.1",
         "webpack": "3.10.0"
@@ -4707,9 +4709,9 @@
       }
     },
     "tendermint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-3.1.0.tgz",
-      "integrity": "sha512-p5xyMWVXHWuo4O5Z5qEjBtRUQMXt0GsO+XqL6Q8F7aWjYPSA3lJU/L5KOwebJAn8iIDucxSlABx3FIEYQxPZbQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-3.1.1.tgz",
+      "integrity": "sha512-Iq7VAc4LMPV3NI0wLHx5jntdVGI4DT/PdmbwfI6Ix4wDXakvsjfHgn39knoXauiD0kbr3Rr07jijqt2pGcU8KA==",
       "requires": {
         "axios": "0.17.1",
         "bn.js": "4.11.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sirajcoin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/llSourcell/sirajcoin#readme",
   "dependencies": {
-    "coins": "^2.2.3",
-    "lotion": "^0.1.10",
+    "coins": "^2.2.4",
+    "lotion": "^0.1.11",
     "mkdirp": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sirajcoin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A cryptocurrency for Siraj Raval's Youtube community",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
It seems like many are having trouble when `npm` tries to install the `es25519-supercop` module. It is a native module and has to run a C compile step, and a lot of times people don't have the proper build tools or a myriad of other issues as we've seen reported.

We upgraded the dependencies to try to install `ed25519-supercop`, but fall back to the pure-JS `supercop.js` alternative which will be easy to install.